### PR TITLE
Group arguments

### DIFF
--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -24,7 +24,7 @@ module Trailblazer
       end
 
     private
-      def build_operation(params)
+      def build_operation(*params)
         self
       end
     end


### PR DESCRIPTION
::run might receive multiple arguments and when ::build_operation is
called those arguments are expanded, thus causing an error because
method definition expects just one argument.

The way other arguments are passed around suggests that they should be
groped in ::build_operation definition.

Fixes failing test.
