### PR TITLE
Require Operation

### DIFF
--- a/lib/trailblazer.rb
+++ b/lib/trailblazer.rb
@@ -1,5 +1,6 @@
+require "trailblazer/operation"
 require "trailblazer/version"
-require 'uber/inheritable_attr'
+require "uber/inheritable_attr"
 
 module Trailblazer
   # Your code goes here...


### PR DESCRIPTION
Operation is one of the main classes we deal with, so it feels a little bit weird that I have to explicitly require it like so

``` ruby
require "trailblazer/operation"

class CreateOperation < Trailblazer::Operation
end
```

What do you think?
