### PR TITLE
Clarify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ class Comment::Operation::Create < Trailblazer::Operation
       contract.save
       # further after_save logic happens here
     end
+
+    contract
   end
 end
 ```


### PR DESCRIPTION
Unless I miss something, this example from README

``` ruby
class Comment::Operation::Create < Trailblazer::Operation
  class Contract < Reform::Form
    property :body
    validates :body, presence: true
  end


  def process(params)
    comment = Comment.new

    validate(params, comment) do |contract|
      contract.save
      # further after_save logic happens here
    end
  end
end
```

should return `contract` from `process` so the next example would make sense in validation failure scenario where we render new and using contract as a form object.

``` ruby
def create
  @contract = Comment::Operation::Create.run(params[:comment]) do |contract|
    return redirect_to(contract.model) # success.
  end

  render :new # failure. re-render form.
end
```

If we won't return `contract`, `process` would return what `validate` returns and that would be the instance of operation, not contract.

In fact, I'm not sure what is the intended behavior. Would you mind clarifying it?

Thanks!
