### PR TITLE
Return the right ActiveModel::Name on operation

### DIFF
--- a/lib/trailblazer/operation/crud.rb
+++ b/lib/trailblazer/operation/crud.rb
@@ -30,6 +30,11 @@ module Trailblazer
         def model_class # considered private.
           self.config[:model] or raise "[Trailblazer] You didn't call Operation::model." # TODO: infer model name.
         end
+        
+        def namespace_name # considered private.
+          return nil if self.config[:model].to_s.deconstantize == ""
+          self.config[:model].to_s.deconstantize.constantize or raise "[Trailblazer] You didn't call Operation::model." # TODO: infer model name.
+        end
       end
 
 

--- a/lib/trailblazer/operation/responder.rb
+++ b/lib/trailblazer/operation/responder.rb
@@ -6,7 +6,7 @@ module Trailblazer::Operation::Responder
 
   module ClassMethods
     def model_name
-      ::ActiveModel::Name.new(self.parent, nil, model_class.to_s) # FIXME: dependency to CRUD.
+      ::ActiveModel::Name.new(model_class, namespace_name, model_class.to_s) # FIXME: dependency to CRUD.
     end
   end
 

--- a/test/responder_test.rb
+++ b/test/responder_test.rb
@@ -1,9 +1,7 @@
 require 'test_helper'
 require 'trailblazer/operation/responder'
 
-class ResponderTest < MiniTest::Spec
-  Song = Struct.new(:id)
-
+class Song
   class Operation < Trailblazer::Operation
     include CRUD
     model Song
@@ -14,13 +12,62 @@ class ResponderTest < MiniTest::Spec
       self
     end
   end
+end
+
+module MyApp
+  class Song
+    class Operation < Trailblazer::Operation
+      include CRUD
+      model Song
+      include Responder
+
+      def process(params)
+        invalid!(self) if params == false
+        self
+      end
+    end
+  end
+end
+
+class ResponderTestForModelWithoutNamespace < MiniTest::Spec
 
   # test ::model_name
-  it { Operation.model_name.plural.must_equal "responder_test_songs" }
+  it { Song::Operation.model_name.name.must_equal "Song" }
+  it { Song::Operation.model_name.singular.must_equal "song" }
+  it { Song::Operation.model_name.plural.must_equal "songs" }
+  it { Song::Operation.model_name.element.must_equal "song" }
+  it { Song::Operation.model_name.human.must_equal "Song" }
+  it { Song::Operation.model_name.collection.must_equal "songs" }
+  it { Song::Operation.model_name.param_key.must_equal "song" }
+  it { Song::Operation.model_name.i18n_key.must_equal :"song" }
+  it { Song::Operation.model_name.route_key.must_equal "songs" }
+  it { Song::Operation.model_name.singular_route_key.must_equal "song" }
 
   # #errors
-  it { Operation[true].errors.must_equal [] }
-  it { Operation[false].errors.must_equal [1] } # TODO: since we don't want responder to render anything, just return _one_ error. :)
+  it { Song::Operation[true].errors.must_equal [] }
+  it { Song::Operation[false].errors.must_equal [1] } # TODO: since we don't want responder to render anything, just return _one_ error. :)
 
   # TODO: integration test with Controller.
+end
+
+
+class ResponderTestForModelWitNamespace < MiniTest::Spec
+  
+    # test ::model_name
+    it { MyApp::Song::Operation.model_name.name.must_equal "MyApp::Song" }
+    it { MyApp::Song::Operation.model_name.singular.must_equal "my_app_song" }
+    it { MyApp::Song::Operation.model_name.plural.must_equal "my_app_songs" }
+    it { MyApp::Song::Operation.model_name.element.must_equal "song" }
+    it { MyApp::Song::Operation.model_name.human.must_equal "Song" }
+    it { MyApp::Song::Operation.model_name.collection.must_equal "my_app/songs" }
+    it { MyApp::Song::Operation.model_name.param_key.must_equal "song" }
+    it { MyApp::Song::Operation.model_name.i18n_key.must_equal :"my_app/song" }
+    it { MyApp::Song::Operation.model_name.route_key.must_equal "songs" }
+    it { MyApp::Song::Operation.model_name.singular_route_key.must_equal "song" }
+
+    # #errors
+    it { MyApp::Song::Operation[true].errors.must_equal [] }
+    it { MyApp::Song::Operation[false].errors.must_equal [1] } # TODO: since we don't want responder to render anything, just return _one_ error. :)
+
+    # TODO: integration test with Controller.
 end


### PR DESCRIPTION
Return the ActiveModel::Name for Op Model Class instead of Op Class

The current file is return ActiveModel::Name with @klass == Thing::Create, thats and operation, and rails responder tries to find and URL for this object that has no routes configure on our rails app.

When we return its parent ActiveModel::Name, its ok, has the right properties and find the path correctly
