### PR TITLE
Fix behavior on when using responders on destroy operation

### DIFF
--- a/lib/trailblazer/operation/controller.rb
+++ b/lib/trailblazer/operation/controller.rb
@@ -71,15 +71,6 @@ module Trailblazer::Operation::Controller
 
     yield @operation if block_given?
 
-    # After #destroy AR returns the object with #destroyed? true, frozen but *true*
-    # so responders consider as a valid object and redirect to model_path(@model.id)
-    #
-    # If it was destroyed, we pass the model instead of operation, and it returns
-    # correctly to models_path
-    if @model.destroyed?
-      respond_with @model
-    else
-      respond_with @operation
-    end
+    respond_with @operation
   end
 end

--- a/lib/trailblazer/operation/responder.rb
+++ b/lib/trailblazer/operation/responder.rb
@@ -13,6 +13,14 @@ module Trailblazer::Operation::Responder
   def to_param
     @model.to_param
   end
+  
+  def destroyed?
+    @model.destroyed?
+  end
+  
+  def persisted?
+    @model.persisted?
+  end
 
   def errors
     return [] if @valid


### PR DESCRIPTION
After #destroy AR returns the object with #destroyed? true, frozen but _true_
so responders consider as a valid object and redirect to model_path(@model.id)

If it was destroyed, we pass the model instead of operation, and it returns
correctly to models_path
