### PR TITLE
Fix autoloading

### DIFF
--- a/lib/trailblazer/autoloading.rb
+++ b/lib/trailblazer/autoloading.rb
@@ -1,4 +1,4 @@
-module Trailblazer::Operation
-  autoload :Controller, 'operation/controller'
-  autoload :Responder, 'operation/responder'
+Trailblazer::Operation.class_eval do
+  autoload :Controller, 'trailblazer/operation/controller'
+  autoload :Responder, 'trailblazer/operation/responder'
 end


### PR DESCRIPTION
reverts 6151c2e8b1ad04e3a9cb60fff6b93c21a316e990

Since Trailblazer::Operation was previously defined as a Class, it cannot be redefined as a module, or you get "Operation is not a module (TypeError)".
