### PR TITLE
Make reform version more flexible.

### DIFF
--- a/trailblazer.gemspec
+++ b/trailblazer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "actionpack", '>= 3.0.0' # this framework works on Rails.
   spec.add_dependency "uber", ">= 0.0.10" # no builder inheritance.
   spec.add_dependency "representable", ">= 2.1.1", "<2.2.0" # Representable::apply.
-  spec.add_dependency "reform", "1.2.0"
+  spec.add_dependency "reform", "~> 1.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
There is no reform 1.2.0 on rubygems what causes `bundle install` to fail.
