### PR TITLE
Add access to errors in Trailblazer::Operation::InvalidContract

### DIFF
--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -151,7 +151,7 @@ module Trailblazer
 
     # When using Op.(), an invalid contract will raise an exception.
     def raise!(contract)
-      raise InvalidContract.new(contract.errors.to_s) if @options[:raise_on_invalid]
+      raise InvalidContract.new(contract.errors) if @options[:raise_on_invalid]
     end
 
     # Instantiate the contract, either by using the user's contract passed into #validate
@@ -184,6 +184,14 @@ module Trailblazer
     end
 
     class InvalidContract < RuntimeError
+
+      attr_reader :errors
+
+      def initialize(errors)
+        super(errors.to_s)
+        @errors = errors.messages
+      end
+
     end
   end
 end

--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -189,8 +189,18 @@ module Trailblazer
 
       def initialize(errors)
         super(errors.to_s)
-        @errors = errors.messages
+        @errors = nest(errors.messages)
       end
+
+      private
+
+        def nest(hash)
+          hash.each_with_object({}) do |(key,value), all|
+            key_parts = key.to_s.split('.').map!(&:to_sym)
+            leaf = key_parts[0...-1].inject(all) { |h, k| h[k] ||= {} }
+            leaf[key_parts.last] = value
+          end
+        end
 
     end
   end


### PR DESCRIPTION
This patch enables a spec to verify that the InvalidContract errors are exactly what they are expected to be.

``` ruby
expect {

  User::Create.( user: {} )

}.to raise_error { |e|
  expect(e).to be_a Trailblazer::Operation::InvalidContract
  expect(e.errors).to eq ({
    email: ['is missing'],
    first_name: ['is missing'],
    last_name: ['is missing']
  })
}
```
