### PR TITLE
add s to anchor for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Comment::Create.call(whatever: "goes", in: "here")
 Comment::Create.(whatever: "goes", in: "here")
 ```
 
-Their high degree of encapsulation makes them a [replacement for test factories](#test), too.
+Their high degree of encapsulation makes them a [replacement for test factories](#tests), too.
 
 [Learn more.](http://trailblazer.to/gems/operation)
 


### PR DESCRIPTION
fixed a link in the readme - was missing a s to link appropriately to the Tests header