### PR TITLE
bugfix: using representer in combination with the validate step macro causes errors

### DIFF
--- a/lib/trailblazer/operation/validate.rb
+++ b/lib/trailblazer/operation/validate.rb
@@ -37,10 +37,10 @@ class Trailblazer::Operation
       # Macro: Validates contract `:name`.
       def self.Call(name:"default", representer:false, params_path:nil)
         step = ->(input, options) {
-          validate!(options, name: name, representer: options["representer.#{name}.class"], params_path: params_path)
+          validate!(options, name: name, representer: options["representer.contract.#{name}.class"], params_path: params_path)
         }
 
-        step = Pipetree::Step.new( step, "representer.#{name}.class" => representer )
+        step = Pipetree::Step.new( step, "representer.contract.#{name}.class" => representer ) # wrapper class to set dependency so it can be used inside the step
 
         [ step, name: "contract.#{name}.call" ]
       end

--- a/test/docs/representer_test.rb
+++ b/test/docs/representer_test.rb
@@ -60,7 +60,7 @@ class DocsRepresenterExplicitTest < Minitest::Spec
   it do
   #:render
   result = Create.({}, "document" => '{"id": 1}')
-  json   = result["representer.default.class"].new(result["model"]).to_json
+  json   = result["representer.contract.default.class"].new(result["model"]).to_json
   json #=> '{"id":1}'
   #:render end
   json.must_equal '{"id":1}'
@@ -83,7 +83,7 @@ class DocsRepresenterExplicitTest < Minitest::Spec
   #:di-call
   result = Create.({},
     "document" => '<body><id>1</id></body>',
-    "representer.default.class" => MyXMLRepresenter # injection
+    "representer.contract.default.class" => MyXMLRepresenter # injection
   )
   #:di-call end
     result.inspect("model").must_equal %{<Result:true [#<struct DocsRepresenterExplicitTest::Song id="1", title=nil>] >}
@@ -113,7 +113,7 @@ class DocsRepresenterDITest < Minitest::Spec
 
   let (:json) { MultiJson.dump(id: 1) }
   it { Create.({}, "document" => json,
-    "representer.default.class" => MyRepresenter).inspect("model").must_equal %{<Result:true [#<struct DocsRepresenterDITest::Song id=1, title=nil>] >} }
+    "representer.contract.default.class" => MyRepresenter).inspect("model").must_equal %{<Result:true [#<struct DocsRepresenterDITest::Song id=1, title=nil>] >} }
 end
 
 #---


### PR DESCRIPTION
Scenario:
Given operation using the 'representer.default.class' skill to generate JSON output
When adding Validate step macro with name 'default' with a dry validator
Then validate step macro fails as a representer will be detected causing failures (the code expects a Reform object in this scenario) + the original representer is overwritten with a nil value due to Pipetree::Step call with dependancy settings

Scenario:
Given operation using the 'representer.default.class' skill to generate JSON output
When adding Validate step macro with name 'default' with a Reform validator using  a second representer (different from the one used for generating the JSON ouput) specified with the 'representer' keyword
Then validate step macro will work but the original representer is overwritten with the second one due to Pipetree::Step call with dependancy settings

Solution: use specific "representer.contract.XXXX.class" skill name when storing the contract representer instead of the "representer.XXXX.class" name