### PR TITLE
CI against Ruby 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.3.1
       gemfile: Gemfile
+    - rvm: 2.4.1
+      gemfile: Gemfile


### PR DESCRIPTION
This Ruby version has been released, and this is available on Travis CI.

https://www.ruby-lang.org/en/news/2017/03/22/ruby-2-4-1-released/