### PR TITLE
Improve tracing of Wrap macro

### DIFF
--- a/lib/trailblazer/operation/wrap.rb
+++ b/lib/trailblazer/operation/wrap.rb
@@ -2,7 +2,7 @@ class Trailblazer::Operation
 
   # false is automatically connected to End.failure.
 
-  def self.Wrap(user_wrap, id: "Wrap/#{rand(100)}", &block)
+  def self.Wrap(user_wrap, id: "Wrap/#{user_wrap}", &block)
     operation_class = Wrap.create_operation(block)
     wrapped         = Wrap::Wrapped.new(operation_class, user_wrap)
 


### PR DESCRIPTION
I thought about checking the class of user_wrap, but every object responds to `.to_s`, so we can use `.to_s` for everything.