### PR TITLE
CI: Use Ruby 2.4.9, 2.5.7, 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
   - gem update --system
   - gem install bundler
 rvm:
-  - 2.5.1
+  - 2.6.4
+  - 2.5.6
   - 2.4.4
   - 2.3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - gem update --system
   - gem install bundler
 rvm:
-  - 2.6.4
-  - 2.5.6
-  - 2.4.4
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9
   - 2.3.7


### PR DESCRIPTION
This PR updates the build matrix: use latest 2.6, 2.5.

2.4.7 was also released, but it didn't have rvm distribution yet, so I excluded that from this PR.


https://www.ruby-lang.org/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/