### PR TITLE
Add metadata URLs

### DIFF
--- a/trailblazer.gemspec
+++ b/trailblazer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.metadata      = {
     "bug_tracker_uri"   => "https://github.com/trailblazer/trailblazer/issues",
     "changelog_uri"     => "https://github.com/trailblazer/trailblazer/blob/master/CHANGES.md",
-    "documentation_uri" => "https://trailblazer.to/2.1/docs/trailblazer.html",
+    "documentation_uri" => "https://trailblazer.to/docs",
     "homepage_uri"      => "https://trailblazer.to/",
     "mailing_list_uri"  => "https://trailblazer.zulipchat.com/",
     "source_code_uri"   => "https://github.com/trailblazer/trailblazer",

--- a/trailblazer.gemspec
+++ b/trailblazer.gemspec
@@ -11,7 +11,16 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{A high-level architecture for Ruby and Rails.}
   spec.homepage      = "http://trailblazer.to"
   spec.license       = "LGPL-3.0"
-
+  spec.metadata      = {
+    "bug_tracker_uri"   => "https://github.com/trailblazer/trailblazer/issues",
+    "changelog_uri"     => "https://github.com/trailblazer/trailblazer/blob/master/CHANGES.md",
+    "documentation_uri" => "https://trailblazer.to/2.1/docs/trailblazer.html",
+    "homepage_uri"      => "https://trailblazer.to/",
+    "mailing_list_uri"  => "https://trailblazer.zulipchat.com/",
+    "source_code_uri"   => "https://github.com/trailblazer/trailblazer",
+    "wiki_uri"          => "https://github.com/trailblazer/trailblazer/wiki"
+  }
+  
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|doc)/})
   end


### PR DESCRIPTION
Adds metadata URLs to gemspec, to support tooling such as rubygems.org links and automated Dependabot dependency update PRs, as per [specification](https://guides.rubygems.org/specification-reference/#metadata).

Relatedly, do you have / could you set up a non-version-specific documentation URL redirect?