### PR TITLE
Fix link to learn docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Trailblazer is both used for refactoring legacy apps (we support Ruby 2.5+) and 
 
 ## Documentation
 
-* **The current version is Trailblazer 2.1.** We do have comprehensive [API documenation](https://trailblazer.to/2.1/docs/trailblazer.html) ready for you. If you're new to TRB start with our [LEARN page](https://trailblazer.to/2.1/learn.html).
+* **The current version is Trailblazer 2.1.** We do have comprehensive [API documenation](https://trailblazer.to/2.1/docs/trailblazer.html) ready for you. If you're new to TRB start with our [LEARN page](https://trailblazer.to/2.1/docs/trailblazer/#trailblazer-learn).
 * A migration guide from 2.0 can be found [on our website](https://trailblazer.to/2.1/docs/trailblazer.html#trailblazer-2-1-migration).
 * The [1.x documentation is here](http://trailblazer.to/2.0/gems/operation/1.1/index.html).
 


### PR DESCRIPTION
Old link lead to:
![image](https://github.com/trailblazer/trailblazer/assets/22965927/7ce31f1a-a544-4844-a6f6-6b62a6b14e49)
